### PR TITLE
Simplify and enhance nginx configuration

### DIFF
--- a/components/terraform/nginx-conf/scripts/nginx.conf
+++ b/components/terraform/nginx-conf/scripts/nginx.conf
@@ -49,7 +49,9 @@ http {
 
     # publicly accessible  beta
     server {
-        set $base_url   %{ if environment == "live" }beta.nationalarchives.gov.uk%{ else }${environment}-beta.nationalarchives.gov.uk%{ endif };
+        set $base_url        %{ if environment == "live" }beta.nationalarchives.gov.uk%{ else }${environment}-beta.nationalarchives.gov.uk%{ endif };
+        set $catalogue_uri   catalogue.${environment}.local;
+        set $ups_catalogue   http://$catalogue_uri;
 
         limit_req zone=one burst=60 nodelay;
 
@@ -88,9 +90,6 @@ http {
         proxy_set_header X-Forwarded-Host    $host;
         proxy_set_header X-Forwarded-Proto   $scheme;
 
-        set $catalogue_uri   catalogue.${environment}.local;
-        set $ups_catalogue   http://$catalogue_uri;
-
         location = / {
             return 302 https://$base_url/catalogue;
         }
@@ -101,7 +100,7 @@ http {
             proxy_pass $ups_catalogue/catalogue/static/$1$is_args$args;
         }
         
-        location = /catalogue {
+        location /catalogue {
             proxy_pass $ups_catalogue;
         }
     }

--- a/components/terraform/nginx-conf/scripts/nginx.conf
+++ b/components/terraform/nginx-conf/scripts/nginx.conf
@@ -91,7 +91,7 @@ http {
         proxy_set_header X-Forwarded-Proto   $scheme;
 
         location = / {
-            return 302 https://$base_url/catalogue;
+            return 302 https://$base_url/catalogue/;
         }
 
         location ~* ^/catalogue/static/(.*)$ {

--- a/components/terraform/nginx-conf/scripts/nginx.conf
+++ b/components/terraform/nginx-conf/scripts/nginx.conf
@@ -23,19 +23,19 @@ http {
                       '"$http_user_agent" "$http_x_forwarded_for" '
                       '-- uri: "$uri" -- request_uri "$request_uri"';
 
-    sendfile            on;
-    sendfile_max_chunk  1m;
+    sendfile             on;
+    sendfile_max_chunk   1m;
 
-    tcp_nopush          on;
-    tcp_nodelay         on;
-    keepalive_timeout   65;
-    types_hash_max_size 4096;
+    tcp_nopush            on;
+    tcp_nodelay           on;
+    keepalive_timeout     65;
+    types_hash_max_size   4096;
 
-    variables_hash_max_size     2048;
-    variables_hash_bucket_size  128;
+    variables_hash_max_size      2048;
+    variables_hash_bucket_size   128;
 
-    include             /etc/nginx/mime.types;
-    default_type        application/octet-stream;
+    include        /etc/nginx/mime.types;
+    default_type   application/octet-stream;
 
     # Load modular configuration files from the /etc/nginx/conf.d directory.
     # See http://nginx.org/en/docs/ngx_core_module.html#include
@@ -49,74 +49,60 @@ http {
 
     # publicly accessible  beta
     server {
+        set $base_url   %{ if environment == "live" }beta.nationalarchives.gov.uk%{ else }${environment}-beta.nationalarchives.gov.uk%{ endif };
+
         limit_req zone=one burst=60 nodelay;
 
         listen          80 default_server;
-        server_name      %{ if environment == "live" }beta.nationalarchives.gov.uk %{ else }${environment}-beta.nationalarchives.gov.uk%{ endif };
+        server_name     $base_url;
         server_tokens   off;
 
-        access_log  /var/log/nginx/public-access.log  main;
-        error_log   /var/log/nginx/public-error.log;
+        access_log   /var/log/nginx/public-access.log main;
+        error_log    /var/log/nginx/public-error.log;
 
         real_ip_header X-Forwarded-For;
         real_ip_recursive on;
 
         include cloudfront_ips.conf;
 
-        gzip         on;
-        gzip_proxied expired no-cache no-store private auth;
-        gzip_types   *;
+        gzip           on;
+        gzip_proxied   expired no-cache no-store private auth;
+        gzip_types     *;
 
         add_header X-Frame-Options          SAMEORIGIN;
         add_header Referrer-Policy          "no-referrer-when-downgrade" always;
         add_header X-XSS-Protection         "1; mode-block";
         add_header X-Content-Type-Options   "nosniff";
-        add_header Content-Security-Policy  "frame-ancestors 'self'";
+        add_header X-Robots-Tag             "noindex, nofollow, nosnippet, noarchive";
 
-        add_header X-Robots-Tag "noindex, nofollow, nosnippet, noarchive";
+        proxy_intercept_errors           off;
+        proxy_buffering                  off;
+        proxy_buffer_size                4k;
+        proxy_http_version               1.1;
+        proxy_headers_hash_max_size      2048;
+        proxy_headers_hash_bucket_size   256;
 
+        proxy_set_header Host                $host;
+        proxy_set_header X-Forwarded-For     $remote_addr;
+        proxy_set_header X-Real-IP           $remote_addr;
+        proxy_set_header X-Forwarded-Host    $host;
+        proxy_set_header X-Forwarded-Proto   $scheme;
 
-        recursive_error_pages on;
+        set $catalogue_uri   catalogue.${environment}.local;
+        set $ups_catalogue   http://$catalogue_uri;
 
-        proxy_intercept_errors          on;
-        proxy_buffering                 off;
-        proxy_buffer_size               4k;
-        proxy_http_version              1.1;
-        proxy_redirect                  off;
-
-        proxy_headers_hash_max_size     2048;
-        proxy_headers_hash_bucket_size  256;
-
-        proxy_pass_request_headers  on;
-        proxy_pass_request_body     on;
-
-        proxy_set_header Host                   $proxy_host;
-        proxy_set_header X-Forwarded-For        $proxy_add_x_forwarded_for;
-        proxy_set_header X-Real-IP              $remote_addr;
-        proxy_set_header X-Forwarded-Host       $host;
-        proxy_set_header X-Forwarded-Proto      $scheme;
-
-        proxy_set_header HTTP_X_FORWARDED_PROTO  $scheme;
-        proxy_set_header HTTP_X_FORWARDED_HOST  $host;
-        proxy_set_header X_HOST_TYPE            "public";
-        proxy_set_header X-NginX-Proxy          true;
-        proxy_set_header Accept-Encoding        "";
-
-        set $root_url   %{ if environment == "live" }beta.nationalarchives.gov.uk%{ else }${environment}-beta.nationalarchives.gov.uk%{ endif };
-        set $catalogue_uri     catalogue.${environment}.local;
-        set $ups_catalogue    http://$catalogue_uri;
-
-
-        location = /catalogue {
-            rewrite ^([^.]*[^/])$ $1/ permanent;
+        location = / {
+            return 302 https://$base_url/catalogue;
         }
-        location ~* ^/catalogue/(.*)$ {
-           proxy_intercept_errors off;
-           proxy_set_header Host $host;
-           proxy_pass $ups_catalogue/catalogue/$1$is_args$args;
-        }
+
         location ~* ^/catalogue/static/(.*)$ {
-            proxy_pass $ups_catalogue/static/$1$is_args$args;
+            expires 1y;
+            access_log off;
+            proxy_pass $ups_catalogue/catalogue/static/$1$is_args$args;
+        }
+        
+        location = /catalogue {
+            proxy_pass $ups_catalogue;
         }
     }
 


### PR DESCRIPTION
- Add redirect for https://beta.nationalarchives.gov.uk/ to https://beta.nationalarchives.gov.uk/catalogue/
- Add long cache time for static files
- Remove some standard configuration options
- Simplify catalogue proxy location